### PR TITLE
look for shared lib from runtime file location by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 identifier.sqlite
 .idea
 node_modules
+.bin
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+# https://github.com/ebuckley/cr-sqlite-go
+
+BASE_OS_NAME := $(shell go env GOOS)
+BASE_OS_ARCH := $(shell go env GOARCH)
+
+BIN_ROOT=$(PWD)/.bin
+export PATH:=$(PATH):$(BIN_ROOT)
+
+NAME=cr-sqlite-go
+ifeq ($(BASE_OS_NAME),windows)
+	NAME=cr-sqlite-go.exe
+endif
+
+print:
+	@echo ""
+	@echo "BASE_OS_NAME:   $(BASE_OS_NAME)"
+	@echo "BASE_OS_ARCH:   $(BASE_OS_ARCH)"
+	@echo ""
+
+all: dep bin
+
+dep:
+	go install github.com/hashicorp/go-getter/cmd/go-getter@latest
+	mv $(GOPATH)/bin/go-getter $(BIN_ROOT)
+
+	# The version...
+	# https://github.com/vlcn-io/cr-sqlite/releases/tag/v0.16.3
+
+	## All the Mobiles.
+	# ios arm64
+	@echo "--- dep: ios ---"
+	go-getter https://github.com/vlcn-io/cr-sqlite/releases/download/v0.16.3/crsqlite-ios-dylib.xcframework.tar.gz $(BIN_ROOT)/crsqlite_ios_arm64
+
+	# android amr64
+	@echo "--- dep: android ---"
+	go-getter https://github.com/vlcn-io/cr-sqlite/releases/download/v0.16.3/crsqlite-aarch64-linux-android.zip $(BIN_ROOT)/crsqlite_android_arm64
+
+	## All the Desktoops / Servers.
+
+#ifeq ($(BASE_OS_NAME),darwin)
+	@echo "--- dep: darwin ---"
+	# darwin amd64
+	go-getter https://github.com/vlcn-io/cr-sqlite/releases/download/v0.16.3/crsqlite-darwin-x86_64.zip $(BIN_ROOT)/crsqlite_darwin_amd64
+
+	# darwin arm64
+	go-getter https://github.com/vlcn-io/cr-sqlite/releases/download/v0.16.3/crsqlite-darwin-aarch64.zip $(BIN_ROOT)/crsqlite_darwin_arm64
+
+#endif
+#ifeq ($(BASE_OS_NAME),linux)
+	@echo "--- dep: linux ---"
+
+	# linux arm64
+	go-getter https://github.com/vlcn-io/cr-sqlite/releases/download/v0.16.3/crsqlite-linux-aarch64.zip  $(BIN_ROOT)/crsqlite_windows_arm64
+	
+	# linux amd64
+	go-getter https://github.com/vlcn-io/cr-sqlite/releases/download/v0.16.3/crsqlite-linux-x86_64.zip $(BIN_ROOT)/crsqlite_windows_amd64
+#endif
+#ifeq ($(BASE_OS_NAME),windows)
+	@echo "--- dep: windows ---"
+
+	# windows arm64
+	# I raised a discussion to have one: https://github.com/vlcn-io/cr-sqlite/discussions/438
+	#go-getter ?? THEX DONT HAVE OONE ??  $(BIN_ROOT)/crsqlite_windows_arm64
+	
+	# windows amd64
+	go-getter https://github.com/vlcn-io/cr-sqlite/releases/download/v0.16.3/crsqlite-win-x86_64.zip $(BIN_ROOT)/crsqlite_windows_amd64
+#endif
+
+
+bin:
+	cd cmd/server && go build -o $(BIN_ROOT)/$(NAME) .
+
+run:
+	$(NAME)
+	# https://localhost:50051
+

--- a/cmd/server/service.go
+++ b/cmd/server/service.go
@@ -1,8 +1,12 @@
 package main
 
 import (
-	"github.com/ebuckley/crsqlite-go/crsql"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sync"
+
+	"github.com/ebuckley/crsqlite-go/crsql"
 )
 
 var schema = `
@@ -10,7 +14,15 @@ create table if not exists note (id primary key not null, title, body);
 select crsql_as_crr('note');
 `
 var setup = sync.OnceFunc(func() {
-	crsql.Register("/home/ersin/Code/crdt-sql/crsql/crsqlite") // TODO make configurable
+	ex, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	exPath := filepath.Dir(ex)
+
+	// Match structure of the .bin path.
+
+	crsql.Register(filepath.Join(exPath, "crsqlite_"+runtime.GOOS+"_"+runtime.GOARCH, "crsqlite"))
 })
 
 func newSyncService() (*crsql.SyncService, error) {


### PR DESCRIPTION
This allows the system to run on all OS more easily.

The make file automates getting the os dependent shared lib.

The service.go was monied to load up the correct lib based on the OS and ARCH and the location that the share libs is placed by the Make file.

I tested this on a Mac arm64 M2 and it worked.

